### PR TITLE
fix: allowing null object properties to remain

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -44,10 +44,13 @@ test('should remove empty arrays from within object', () => {
     },
     d: [1234, undefined],
     e: [],
+    f: null,
+    g: [null, undefined, null],
   };
 
   expect(removeUndefinedObjects(obj)).toStrictEqual({
     d: [1234],
+    f: null,
   });
 });
 


### PR DESCRIPTION
## 🧰 Changes

This resolves an issue I discovered in `@readme/oas-to-har` where is a body payload was `{foo: null}` this library would delete it, resulting in `@readme/oas-to-har` crafting an `undefined` `postData` payload.

```js
const spec = new Oas({
  paths: {
    '/requestBody': {
      post: {
        requestBody: {
          required: true,
          content: {
            'application/json': {
              schema: {
                type: 'object',
                properties: {
                  foo: {
                    type: 'string',
                  },
                },
              },
            },
          },
        },
      },
    },
  },
});

console.log(oasToHar(spec, spec.operation('/requestBody', 'post'), { body: { foo: null } }))
```

```js
{
  log: {
    entries: [
      {
        request: {
          cookies: [],
          headers: [{ name: "Content-Type", value: "application/json" }],
          headersSize: 0,
          queryString: [],
          postData: { mimeType: "application/json", text: undefined },
          bodySize: 0,
          method: "POST",
          url: "https://example.com/requestBody",
          httpVersion: "HTTP/1.1",
        },
      },
    ],
  },
}
```

This undefined `postData` payload would then cause a fatal error in our `fetch-har` library because it was attempting to do an `undefined.length` check on [this line](https://github.com/readmeio/fetch-har/blob/main/index.js#L268).

Because sending nullish object properties is a very valid use case in an API, we should allow these through. Null array entries will continue to be removed.