### PR TITLE
fix: typescript typings being rewritten on return

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,5 +1,15 @@
 import removeUndefinedObjects from '../src';
 
+describe('typings', () => {
+  it('should not blow away typings from supplied objects', () => {
+    const obj: { key: string } = removeUndefinedObjects({
+      key: 'buster',
+    });
+
+    expect(obj).toBeDefined();
+  });
+});
+
 test('should leave primitives alone', () => {
   expect(removeUndefinedObjects(1234)).toBe(1234);
   expect(removeUndefinedObjects('1234')).toBe('1234');

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ function stripEmptyObjects(obj: any) {
   return cleanObj.filter(el => el !== undefined);
 }
 
-export default function removeUndefinedObjects(obj?: unknown) {
+export default function removeUndefinedObjects<T>(obj?: T): T {
   if (obj === undefined) {
     return undefined;
   }


### PR DESCRIPTION
## 🧰 Changes

This fixes a problem with the types of objects coming back from this library being rewritten to `any`.
