### PR TITLE
fix: esm issue in `exports` object

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },


### PR DESCRIPTION
## 🧰 Changes

Fixes an issue where we're incorrectly pointing to the CJS types for both the ESM and CJS exports. Instead we should be able to remove the `types` definition entirely and rely on the inferred types.

## 🧬 QA & Testing

The current version of this package yields this on [**_Are The Types Wrong_**](https://arethetypeswrong.github.io/?p=remove-undefined-objects%404.0.2):

<img width="652" alt="image" src="https://github.com/readmeio/remove-undefined-objects/assets/8854718/9e2da948-e365-4864-8fdf-c98996700885">

When testing against the changes, it yields this:

<img width="645" alt="CleanShot 2023-09-20 at 10 47 49@2x" src="https://github.com/readmeio/remove-undefined-objects/assets/8854718/af18adc1-8c45-44c6-b96c-d8f4ceedffeb">


