### PR TITLE
feat: add removeAllFalsy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ The following items will NOT be removed:
 
 * Empty string, `''`
 * Null, `null`
+
+## Options
+
+### `removeAllFalsy`
+
+Optional boolean.
+If provided, the empty string `''` and `null` will be removed as well.
+
+```js
+import removeUndefinedObjects from 'remove-undefined-objects';
+
+console.log(removeUndefinedObjects({key1: null, key2: 123, key3: ''}), {removeAllFalsy: true});
+// { key2: 123 }
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ function isEmptyObject(obj: unknown) {
   return typeof obj === 'object' && obj !== null && !Object.keys(obj).length;
 }
 
-export interface RemovalOptions {
+interface RemovalOptions {
   removeAllFalsy?: boolean;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -20,6 +20,20 @@ test('should leave primitives alone', () => {
   expect(removeUndefinedObjects(undefined)).toBeUndefined();
 });
 
+test('should leave only truthy primitives alone when removeAllFalsy is true', () => {
+  expect(removeUndefinedObjects(1234, { removeAllFalsy: true })).toBe(1234);
+  expect(removeUndefinedObjects('1234', { removeAllFalsy: true })).toBe('1234');
+  expect(removeUndefinedObjects(null, { removeAllFalsy: true })).toBeUndefined();
+  expect(removeUndefinedObjects(undefined, { removeAllFalsy: true })).toBeUndefined();
+});
+
+test("should also remove '' and null values when removeAllFalsy is true", () => {
+  expect(removeUndefinedObjects({ value: 1234 }, { removeAllFalsy: true })).toStrictEqual({ value: 1234 });
+  expect(removeUndefinedObjects({ value: '1234' }, { removeAllFalsy: true })).toStrictEqual({ value: '1234' });
+  expect(removeUndefinedObjects({ value: null }, { removeAllFalsy: true })).toBeUndefined();
+  expect(removeUndefinedObjects({ value: undefined }, { removeAllFalsy: true })).toBeUndefined();
+});
+
 test('should remove empty objects with only empty properties', () => {
   const obj = {
     a: {
@@ -63,6 +77,25 @@ test('should remove empty arrays from within object', () => {
   expect(removeUndefinedObjects(obj)).toStrictEqual({
     d: [1234],
     f: null,
+  });
+});
+
+test('should remove empty arrays and falsy values from within object when removeAllFalsy is true', () => {
+  const obj = {
+    a: {
+      b: undefined,
+      c: {
+        d: undefined,
+      },
+    },
+    d: [1234, undefined],
+    e: [],
+    f: null,
+    g: [null, undefined, null],
+  };
+
+  expect(removeUndefinedObjects(obj, { removeAllFalsy: true })).toStrictEqual({
+    d: [1234],
   });
 });
 


### PR DESCRIPTION
| 🚥 Fixes #126 |
| :------------------- |

## 🧰 Changes

Adds and documents an optional `removeAllFalsy` flag in a new optional options object. If true, `''` and `null` will also be removed from objects.

## 🧬 QA & Testing

I added unit tests and ran them.