### PR TITLE
refactor: retain null values in array

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -77,6 +77,7 @@ test('should remove empty arrays from within object', () => {
   expect(removeUndefinedObjects(obj)).toStrictEqual({
     d: [1234],
     f: null,
+    g: [null, null],
   });
 });
 
@@ -99,11 +100,12 @@ test('should remove empty arrays and falsy values from within object when remove
   });
 });
 
-test('should remove undefined and null values from arrays', () => {
+test('should remove undefined values from arrays & not null values', () => {
   expect(removeUndefinedObjects([undefined, undefined])).toBeUndefined();
-  expect(removeUndefinedObjects([null])).toBeUndefined();
+  expect(removeUndefinedObjects([null])).toStrictEqual([null]);
   expect(removeUndefinedObjects(['1234', null, undefined, { a: null, b: undefined }, '   ', ''])).toStrictEqual([
     '1234',
+    null,
     {
       a: null,
     },


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

- This PR is part of the work for the readme ticket [RM-9906 Not displaying null values in an array](https://linear.app/readme-io/issue/RM-9906/not-displaying-null-values-in-an-array) and should get merged first before the changes in the oas repo
- Removes the JSON.parse(stringify) code in favour implementing own function to remove undefined objects so that undefined values don't get converted to nulls, allowing us to separate user added nulls
-  In addition, don't remove null values in arrays when stripping objects. I think this is fine todo because from my understanding that code was just to removed the null-converted undefined, please let me know if I'm wrong. Open to feedback on how to approach this.

## 🧬 QA & Testing

- To the removeUndefinedObjects function, pass in an array with nulls and they should get retained 
- Primitive nulls should get retained, undefined should still get filtered
