### PR TITLE
feat: add option to preserve empty objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ console.log(
 // { key1: [], key2: [], nested: { key3: 'a', key4: [] } }
 ```
 
+### `preserveEmptyObject`
+
+Optional boolean.
+If provided, empty objects `{}` will not get removed.
+
+```js
+import removeUndefinedObjects from 'remove-undefined-objects';
+
+console.log(removeUndefinedObjects({ key1: {}, key2: { nested: undefined }, key3: 123 }));
+// { key3: 123 }
+
+console.log(
+  removeUndefinedObjects({ key1: {}, key2: { nested: undefined }, key3: 123 }, { preserveEmptyObject: true }),
+);
+// { key1: {}, key2: {}, key3: 123 }
+```
+
 ### `preserveNullishArrays`
 
 Optional boolean.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ console.log(
 ### `preserveEmptyObject`
 
 Optional boolean.
-If provided, empty objects `{}` will not get removed.
+If provided, empty objects will not be removed.
 
 ```js
 import removeUndefinedObjects from 'remove-undefined-objects';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ function isEmptyArray(arr: unknown) {
 
 interface RemovalOptions {
   preserveEmptyArray?: boolean;
+  preserveEmptyObject?: boolean;
   preserveNullishArrays?: boolean;
   removeAllFalsy?: boolean;
 }
@@ -71,7 +72,7 @@ function stripEmptyObjects(obj: any, options: RemovalOptions = {}) {
 
       value = stripEmptyObjects(value, options);
 
-      if (isEmptyObject(value)) {
+      if (isEmptyObject(value) && !options.preserveEmptyObject) {
         delete cleanObj[key];
       } else if (isEmptyArray(value) && !options.preserveEmptyArray) {
         delete cleanObj[key];
@@ -88,7 +89,7 @@ function stripEmptyObjects(obj: any, options: RemovalOptions = {}) {
     if (typeof value === 'object' && value !== null) {
       value = stripEmptyObjects(value, options);
 
-      if (isEmptyObject(value)) {
+      if (isEmptyObject(value) && !options.preserveEmptyObject) {
         delete cleanObj[idx];
       } else if (isEmptyArray(value) && !options.preserveEmptyArray) {
         delete cleanObj[idx];
@@ -121,7 +122,10 @@ export default function removeUndefinedObjects<T>(obj?: T, options?: RemovalOpti
   withoutUndefined = stripEmptyObjects(withoutUndefined, options);
 
   // If the only thing that's leftover is an empty object or empty array then return nothing.
-  if (isEmptyObject(withoutUndefined) || (isEmptyArray(withoutUndefined) && !options?.preserveEmptyArray)) {
+  if (
+    (isEmptyObject(withoutUndefined) && !options?.preserveEmptyObject) ||
+    (isEmptyArray(withoutUndefined) && !options?.preserveEmptyArray)
+  ) {
     return;
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,6 +90,32 @@ it('should remove empty objects with only undefined properties', () => {
   expect(removeUndefinedObjects(obj)).toBeUndefined();
 });
 
+it('should not remove empty objects when preserveEmptyObject is true', () => {
+  expect(removeUndefinedObjects({}, { preserveEmptyObject: true })).toStrictEqual({});
+  expect(removeUndefinedObjects({ value: {} }, { preserveEmptyObject: true })).toStrictEqual({ value: {} });
+  expect(removeUndefinedObjects({ value: { nested: {} } }, { preserveEmptyObject: true })).toStrictEqual({
+    value: { nested: {} },
+  });
+});
+
+it('should preserve objects that become empty after removing undefined properties', () => {
+  expect(removeUndefinedObjects({ value: { nested: undefined } }, { preserveEmptyObject: true })).toStrictEqual({
+    value: {},
+  });
+  expect(
+    removeUndefinedObjects(
+      {
+        value: {
+          nested: {
+            deeper: undefined,
+          },
+        },
+      },
+      { preserveEmptyObject: true },
+    ),
+  ).toStrictEqual({ value: { nested: {} } });
+});
+
 it('should remove empty arrays from within object', () => {
   const obj = {
     a: {
@@ -140,6 +166,19 @@ it('should remove undefined and null values from arrays', () => {
     '   ',
     '',
   ]);
+});
+
+it('should not remove empty object values from arrays when preserveEmptyObject is true', () => {
+  expect(removeUndefinedObjects([{}, { a: undefined }, { b: 'b' }], { preserveEmptyObject: true })).toStrictEqual([
+    {},
+    {},
+    { b: 'b' },
+  ]);
+  expect(
+    removeUndefinedObjects({ value: [{}, { a: undefined }, { b: [] }] }, { preserveEmptyObject: true }),
+  ).toStrictEqual({
+    value: [{}, {}, {}],
+  });
 });
 
 it('should not remove null values from arrays when preserveArrayNulls is true', () => {


### PR DESCRIPTION
| 🚥 Resolves [CX-1601](https://linear.app/readme-io/issue/CX-1601/cant-send-empty-data-arrayobject-in-try-it) |
| :------------------ |

## 🧰 Changes

Adds a new `preserveEmptyObject` option so callers can keep empty objects instead of having them stripped during cleanup.

By default, `remove-undefined-objects` still removes `{}` the same way it did before. When `preserveEmptyObject: true` is passed, empty objects are preserved at the root, inside object properties, and inside arrays. This also covers objects that become empty after `undefined` properties are removed.

This is needed for cases where an empty object is intentional request data, like Try It payloads where `{}` should still be sent instead of removed.

## 🧬 QA & Testing

Verified the existing default behavior still strips empty objects when no option is passed.

Verified `preserveEmptyObject: true` preserves:

- a top-level `{}`
- nested empty object properties
- objects that become empty after removing `undefined` properties
- empty object entries inside arrays